### PR TITLE
Make route graph, vertical route graph data fields unclickable in preview mode

### DIFF
--- a/app/src/main/kotlin/de/timklge/karooroutegraph/datatypes/RouteGraphDataType.kt
+++ b/app/src/main/kotlin/de/timklge/karooroutegraph/datatypes/RouteGraphDataType.kt
@@ -450,7 +450,11 @@ class RouteGraphDataType(
                 }
 
                 val result = glance.compose(context, DpSize.Unspecified) {
-                    Box(modifier = GlanceModifier.fillMaxSize().clickable(actionRunCallback(ChangeZoomLevelAction::class.java))){
+                    var modifier = GlanceModifier.fillMaxSize()
+
+                    if (!config.preview) modifier = modifier.clickable(onClick = actionRunCallback<ChangeZoomLevelAction>())
+
+                    Box(modifier = modifier){
                         Image(ImageProvider(bitmap), "Route Graph", modifier = GlanceModifier.fillMaxSize())
                     }
                 }

--- a/app/src/main/kotlin/de/timklge/karooroutegraph/datatypes/VerticalRouteGraphDataType.kt
+++ b/app/src/main/kotlin/de/timklge/karooroutegraph/datatypes/VerticalRouteGraphDataType.kt
@@ -421,8 +421,11 @@ class VerticalRouteGraphDataType(
                 }
 
                 val result = glance.compose(context, DpSize.Unspecified) {
-                    Box(modifier = GlanceModifier.fillMaxSize().clickable(actionRunCallback(ChangeZoomLevelAction::class.java))) {
-                        Image(ImageProvider(bitmap), "Route Graph", modifier = GlanceModifier.fillMaxSize())
+                    var modifier = GlanceModifier.fillMaxSize()
+
+                    if (!config.preview) modifier = modifier.clickable(onClick = actionRunCallback<ChangeZoomLevelAction>())
+
+                    Box(modifier = modifier) {
                         Image(ImageProvider(bitmap), "Route Graph", modifier = GlanceModifier.fillMaxSize())
                     }
                 }


### PR DESCRIPTION
fix #10 