### PR TITLE
Remove y axis, POI labels of route graph when placed in 1x1 datafield

### DIFF
--- a/app/src/main/kotlin/de/timklge/karooroutegraph/KarooRouteGraphExtension.kt
+++ b/app/src/main/kotlin/de/timklge/karooroutegraph/KarooRouteGraphExtension.kt
@@ -239,9 +239,9 @@ class KarooRouteGraphExtension : KarooExtension("karoo-routegraph", BuildConfig.
             )
 
             val redrawInterval = if (karooSystem.karooSystemService.hardwareType == HardwareType.K2) {
-                3.seconds
+                4.seconds
             } else {
-                1.seconds
+                2.seconds
             }
 
             combine(applicationContext.streamSettings(karooSystem.karooSystemService), locationFlow, zoomLevelFlow, routeGraphViewModelProvider.viewModelFlow) { settings, location, mapZoom, viewModel ->


### PR DESCRIPTION
In its previous iterations, the route graph did not really fit into a 1x1 grid cell, mainly because the Y-Axis, its labels and the POI labels clutter the small space and the actual elevation profile was not discernible. The native karoo elevation profile manages this better and looks minimalistic in a 1x1 cell.

This updates the field to remove all stuff that doesn't fit in a 1x1 field:

![grafik](https://github.com/user-attachments/assets/e429c9fe-e338-445b-8d43-fea77dac6510)
