### PR TITLE
Do not rotate chevrons by gps bearing as symbols now rotate with the Karoo map, reduce draw rate

### DIFF
--- a/app/src/main/kotlin/de/timklge/karooroutegraph/KarooRouteGraphExtension.kt
+++ b/app/src/main/kotlin/de/timklge/karooroutegraph/KarooRouteGraphExtension.kt
@@ -238,9 +238,9 @@ class KarooRouteGraphExtension : KarooExtension("karoo-routegraph", BuildConfig.
             )
 
             val redrawInterval = if (karooSystem.karooSystemService.hardwareType == HardwareType.K2) {
-                5.seconds
+                15.seconds
             } else {
-                3.seconds
+                10.seconds
             }
 
             combine(applicationContext.streamSettings(karooSystem.karooSystemService), locationFlow, zoomLevelFlow, routeGraphViewModelProvider.viewModelFlow) { settings, location, mapZoom, viewModel ->
@@ -320,7 +320,7 @@ class KarooRouteGraphExtension : KarooExtension("karoo-routegraph", BuildConfig.
                             lat = position.latitude(),
                             lng = position.longitude(),
                             iconRes = gradientIndicator.drawableRes,
-                            orientation = bearing.toFloat() - (location.orientation ?: 0.0).toFloat(),
+                            orientation = bearing.toFloat(),
                         )
                     }
                     emitter.onNext(ShowSymbols(icons))


### PR DESCRIPTION
fix #22 