### PR TITLE
Use max POI distance to route setting when auto-adding POIs to the map

### DIFF
--- a/app/src/main/kotlin/de/timklge/karooroutegraph/RouteGraphUpdateManager.kt
+++ b/app/src/main/kotlin/de/timklge/karooroutegraph/RouteGraphUpdateManager.kt
@@ -500,7 +500,7 @@ class RouteGraphUpdateManager(
                                 offlineNearbyPOIProvider.requestNearbyPOIs(
                                     poiSettings.autoAddPoiCategories.map { it.osmTag }.flatten(),
                                     listOf(currentLocation),
-                                    2_000,
+                                    settings.poiDistanceToRouteMaxMeters.toInt() * 4,
                                     200
                                 ).forEach { poi ->
                                     val symbol = Symbol.POI(


### PR DESCRIPTION
fix #197 